### PR TITLE
Resolve #40 by removing the TextShow I16 instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## next [????.??.??]
+* Remove the `TextShow I16` instance from `TextShow.Data.Text`. The usefulness
+  of this instance was dubious at best, and moreover, it was actively causing
+  issues when building `text-show` with `reflex-platform` (see
+  [#40](https://github.com/RyanGlScott/text-show/issues/40)).
+
 ### 3.7.5 [2018.10.07]
 * _Actually_ make `showbEFloat`'s behavior match that of `showEFloat` in
   `base-4.12`.

--- a/src/TextShow/Data/Text.hs
+++ b/src/TextShow/Data/Text.hs
@@ -13,7 +13,13 @@ Maintainer:  Ryan Scott
 Stability:   Provisional
 Portability: GHC
 
-'TextShow' instances for 'Text' types.
+Defines 'TextShow' instances for 'Text' types, as well as other miscellaneous
+data types from the @text@ package.
+
+Note that this module deliberately does not define a 'TextShow' instance for
+the @I16@ data type from @Data.Text.Foreign@, as that module is not available
+on certain widely used variants of GHC (e.g., @reflex-platform@). See #40
+for more details. If this is a problem for you, please file an issue.
 
 /Since: 2/
 -}
@@ -21,7 +27,6 @@ module TextShow.Data.Text () where
 
 import qualified Data.Text as TS
 import           Data.Text.Encoding.Error (UnicodeException(..))
-import           Data.Text.Foreign (I16)
 import qualified Data.Text.Lazy as TL
 import           Data.Text.Lazy.Builder (Builder, fromString, toLazyText)
 
@@ -59,9 +64,6 @@ instance TextShow TL.Text where
 instance TextShow Builder where
     showb = showb . toLazyText
     {-# INLINE showb #-}
-
--- | /Since: 2/
-$(deriveTextShow ''I16)
 
 -- | /Since: 2/
 instance TextShow UnicodeException where

--- a/tests/Instances/Data/Text.hs
+++ b/tests/Instances/Data/Text.hs
@@ -17,7 +17,6 @@ Portability: GHC
 module Instances.Data.Text () where
 
 import Data.Text.Encoding.Error (UnicodeException(..))
-import Data.Text.Foreign (I16)
 import Data.Text.Lazy.Builder (Builder, fromString)
 
 #if MIN_VERSION_text(1,0,0)
@@ -37,14 +36,11 @@ import Instances.Utils.GenericArbitrary (genericArbitrary)
 import Prelude ()
 import Prelude.Compat
 
-import Test.QuickCheck (Arbitrary(..), arbitraryBoundedEnum)
+import Test.QuickCheck (Arbitrary(..))
 import Test.QuickCheck.Instances ()
 
 instance Arbitrary Builder where
     arbitrary = fromString <$> arbitrary
-
-instance Arbitrary I16 where
-    arbitrary = arbitraryBoundedEnum
 
 instance Arbitrary UnicodeException where
     arbitrary = genericArbitrary

--- a/tests/Spec/Data/TextSpec.hs
+++ b/tests/Spec/Data/TextSpec.hs
@@ -26,7 +26,6 @@ import qualified Data.Text as TL
 import           Data.Text.Encoding (Decoding)
 #endif
 import           Data.Text.Encoding.Error (UnicodeException)
-import           Data.Text.Foreign (I16)
 #if MIN_VERSION_text(1,1,0)
 import           Data.Text.Internal.Fusion.Size (Size)
 #endif
@@ -43,8 +42,6 @@ spec = parallel $ do
         matchesTextShowSpec (Proxy :: Proxy TS.Text)
     describe "lazy Text" $
         matchesTextShowSpec (Proxy :: Proxy TL.Text)
-    describe "I16" $
-        matchesTextShowSpec (Proxy :: Proxy I16)
     describe "UnicodeException" $
         matchesTextShowSpec (Proxy :: Proxy UnicodeException)
 #if MIN_VERSION_text(1,0,0)


### PR DESCRIPTION
The usefulness of this instance was dubious at best, and moreover, it was actively causing issues when building `text-show` with `reflex-platform` (see #40).