### PR TITLE
Don't depend on integer-gmp if using GHC 9.0+

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.14
 #
-# REGENDATA ("0.13.20211116",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.14",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -33,10 +33,10 @@ jobs:
             compilerVersion: 9.2.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### next [????.??.??]
+* `text-show` no longer depends on `integer-gmp` when built with GHC 9.0 or
+  later.
+
 ### 3.9.5 [2022.01.03]
 * Work around a GHC 8.0–specific issue in which GHC's simplifier ticks would
   become exhausted, causing compilation to fail.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,9 @@ environment:
   global:
     CABOPTS:  "--store-dir=C:\\SR --http-transport=plain-http --enable-tests --enable-benchmarks"
   matrix:
-    - GHCVER: "9.0.1"
-    - GHCVER: "8.10.4"
+    - GHCVER: "9.2.1"
+    - GHCVER: "9.0.2"
+    - GHCVER: "8.10.7"
     - GHCVER: "8.8.4.1"
     - GHCVER: "8.6.5"
     - GHCVER: "8.4.4"

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -162,7 +162,6 @@ library
                      , containers            >= 0.1    && < 0.7
                      , generic-deriving      >= 1.14.1 && < 2
                      , ghc-prim
-                     , integer-gmp
                      , text                  >= 0.11.1 && < 2.1
                      , th-abstraction        >= 0.4    && < 0.5
                      , th-lift               >= 0.7.6  && < 1
@@ -185,6 +184,14 @@ library
     cpp-options:       "-DNEW_FUNCTOR_CLASSES"
   else
     build-depends:     transformers          == 0.4.*
+
+  -- integer-gmp is only needed on pre-9.0 versions of GHC, as GHC 9.0+ add
+  -- enough functionality to base to avoid the use of integer-gmp entirely.
+  -- Ideally, one would be able to choose between integer-gmp and
+  -- integer-simple on pre-9.0 versions of GHC, but that is not currently
+  -- possible due to #31.
+  if !impl(ghc >= 9.0)
+    build-depends:     integer-gmp
 
   hs-source-dirs:      src, shared
   default-language:    Haskell2010

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -51,7 +51,7 @@ tested-with:         GHC == 7.8.4
                    , GHC == 8.6.5
                    , GHC == 8.8.4
                    , GHC == 8.10.7
-                   , GHC == 9.0.1
+                   , GHC == 9.0.2
                    , GHC == 9.2.1
 extra-source-files:  CHANGELOG.md, README.md, include/*.h
 cabal-version:       >=1.10


### PR DESCRIPTION
This dependency isn't needed on recent GHCs. See the discussion in #31.