### PR TITLE
Scale back instances in `TextShow.FromStringTextShow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+## 3.10 [????.??.??]
+* The instances in `TextShow.FromStringTextShow` module have been scaled back
+  somewhat for forward compatibility with Core Libraries proposal #10, which
+  will add quantified `Show` superclasses to `Show1` and `Show2`:
+  * `FromStringShow` and `FromTextShow` no longer have `Show1` or `TextShow1`
+    instances. If you want to derive instances of `Show1` or `TextShow1` via
+    a newtype, use `FromStringShow1` or `FromTextShow1` instead.
+  * The `Show` instances for `FromTextShow1` and `FromTextShow2` have had their
+    instance contexts changed to accommodate the new superclasses in `Show1`
+    and `Show2`:
+
+    ```diff
+    -instance (TextShow1 f, TextShow a) => Show (FromTextShow1 f a)
+    +instance (TextShow1 f, Show a)     => Show (FromTextShow1 f a)
+
+    -instance (TextShow2 f, TextShow a, TextShow b) => Show (FromTextShow2 f a b)
+    +instance (TextShow2 f, Show a,     Show b)     => Show (FromTextShow2 f a b)
+    ```
+
+    While these instances do technically work, they are probably not what you
+    would have in mind if you wanted to derive a `Show` instance purely in
+    terms of `TextShow` classes. For this reason, if you want to derive an
+    instance of `Show` via a newtype, use `FromTextShow` instead.
+  * By similar reasoning, the `Show1` instance for `FromTextShow2` has had its
+    instance context changed:
+
+    ```diff
+    -instance (TextShow2 f, TextShow a) => Show1 (FromTextShow2 f a)
+    +instance (TextShow2 f, Show a)     => Show1 (FromTextShow2 f a)
+    ```
+  * By similar reasoning, the `TextShow` instances for `FromStringShow1` and
+    `FromStringShow2`, as well as the `TextShow1` instance for
+    `FromStringShow2`, have had their instance contexts changed:
+
+    ```diff
+    -instance (Show1 f, Show a)     => TextShow (FromStringShow1 f a)
+    +instance (Show1 f, TextShow a) => TextShow (FromStringShow1 f a)
+
+    -instance (Show2 f, Show a,     Show b)     => TextShow (FromStringShow2 f a b)
+    +instance (Show2 f, TextShow a, TextShow b) => TextShow (FromStringShow2 f a b)
+
+    -instance (Show2 f, Show a)     => TextShow1 (FromStringShow2 f a)
+    +instance (Show2 f, TextShow a) => TextShow1 (FromStringShow2 f a)
+    ```
+
 ### 3.9.7 [2022.05.28]
 * Allow the test suite to build with GHC 9.4.
 * Allow building with `transformers-0.6.*`.

--- a/tests/Spec/FromStringTextShowSpec.hs
+++ b/tests/Spec/FromStringTextShowSpec.hs
@@ -14,12 +14,12 @@ module Spec.FromStringTextShowSpec (main, spec) where
 
 import Data.Proxy.Compat (Proxy(..))
 import Instances.FromStringTextShow ()
-import Spec.Utils (matchesTextShowSpec, matchesTextShow1Spec)
+import Spec.Utils (matchesTextShowSpec)
 import Test.Hspec (Spec, describe, hspec, parallel)
 import TextShow (FromStringShow(..), FromTextShow(..))
 
 #if defined(NEW_FUNCTOR_CLASSES)
-import Spec.Utils (matchesTextShow2Spec)
+import Spec.Utils (matchesTextShow1Spec, matchesTextShow2Spec)
 import TextShow (FromStringShow1(..), FromStringShow2(..),
                  FromTextShow1(..), FromTextShow2(..))
 #endif
@@ -33,43 +33,33 @@ spec = parallel $ do
         let p :: Proxy (FromStringShow Int)
             p = Proxy
         matchesTextShowSpec  p
-        matchesTextShow1Spec p
     describe "FromStringShow String" $ do
         let p :: Proxy (FromStringShow String)
             p = Proxy
         matchesTextShowSpec  p
-        matchesTextShow1Spec p
     describe "FromTextShow Int" $ do
         let p :: Proxy (FromTextShow Int)
             p = Proxy
         matchesTextShowSpec  p
-        matchesTextShow1Spec p
     describe "FromTextShow String" $ do
         let p :: Proxy (FromTextShow String)
             p = Proxy
         matchesTextShowSpec  p
-        matchesTextShow1Spec p
 #if defined(NEW_FUNCTOR_CLASSES)
     describe "FromStringShow1 Maybe Int" $ do
         let p :: Proxy (FromStringShow1 Maybe Int)
             p = Proxy
-        matchesTextShowSpec  p
         matchesTextShow1Spec p
     describe "FromTextShow1 Maybe Int" $ do
         let p :: Proxy (FromTextShow1 Maybe Int)
             p = Proxy
-        matchesTextShowSpec  p
         matchesTextShow1Spec p
     describe "FromStringShow2 Either Char Int" $ do
         let p :: Proxy (FromStringShow2 Either Char Int)
             p = Proxy
-        matchesTextShowSpec  p
-        matchesTextShow1Spec p
         matchesTextShow2Spec p
     describe "FromTextShow2 Either Char Int" $ do
         let p :: Proxy (FromTextShow2 Either Char Int)
             p = Proxy
-        matchesTextShowSpec  p
-        matchesTextShow1Spec p
         matchesTextShow2Spec p
 #endif

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -1,5 +1,5 @@
 name:                text-show
-version:             3.9.7
+version:             3.10
 synopsis:            Efficient conversion of values into Text
 description:         @text-show@ offers a replacement for the @Show@ typeclass intended
                      for use with @Text@ instead of @String@s. This package was created


### PR DESCRIPTION
This is needed for forward compatibility with haskell/core-libraries-committee#10, which proposes to add quantified `Show` superclasses to `Show1` and `Show2`. Unfortunately, several of the instances in `TextShow.FromStringTextShow` do not mesh well with these new superclasses, so several of the instances have to either be removed or have their instance contexts changed as a consequence. It's a bit heavy-handed, but I'm not sure there exists a better approach. See the `CHANGELOG` for details.

This can be seen as a scaled back version of #55 that only changes instances. In particular, it does _not_ add quantified `TextShow` superclasses to `TextShow1` or `TextShow2`. See #56, which discusses that point separately.