### PR TITLE
Allow building with GHC 9.6

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -266,7 +266,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          if [ $((HCNUMVER < 80000 || HCNUMVER >= 80400)) -ne 0 ] ; then $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.3
+# version: 0.15.20230304
 #
-# REGENDATA ("0.14.3",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.15.20230304",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +28,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.6.0.20230302
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.6.0.20230302
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.4.4
+            compilerKind: ghc
+            compilerVersion: 9.4.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.7
+            compilerKind: ghc
+            compilerVersion: 9.2.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -86,18 +96,20 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -115,20 +127,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -157,6 +169,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -180,7 +204,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -210,6 +234,9 @@ jobs:
           package text-show
             ghc-options: -Werror
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(text-show)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -217,8 +244,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -239,4 +266,10 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### next [????.??.??]
 * Allow building with GHC 9.6.
+* Add `TextShow` instances for `SomeChar` (if building with `base-4.16` or
+  later), as well as `SNat`, `SSymbol`, and `SChar` (if building with
+  `base-4.18` or later).
 
 ### 3.10.1 [2023.02.27]
 * Support `th-abstraction-0.5.*`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### next [????.??.??]
+* Allow building with GHC 9.6.
+
 ### 3.10.1 [2023.02.27]
 * Support `th-abstraction-0.5.*`.
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,3 +2,5 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 local-ghc-options:      -Werror
+-- Work around https://github.com/haskell/haddock/issues/574
+haddock:                <8.0 || >=8.4

--- a/src/TextShow/Data/Tuple.hs
+++ b/src/TextShow/Data/Tuple.hs
@@ -122,6 +122,10 @@ instance TextShow a => TextShow (Solo a) where
 
 -- | /Since: 3.9.3/
 instance TextShow1 Solo where
-    liftShowbPrec sp _ p (Solo x) = showbUnaryWith sp "Solo" p x
+# if MIN_VERSION_ghc_prim(0,10,0)
+    liftShowbPrec sp _ p (MkSolo x) = showbUnaryWith sp "MkSolo" p x
+# else
+    liftShowbPrec sp _ p (Solo   x) = showbUnaryWith sp "Solo"   p x
+# endif
     {-# INLINE liftShowbPrec #-}
 #endif

--- a/src/TextShow/GHC/TypeLits.hs
+++ b/src/TextShow/GHC/TypeLits.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-|
 Module:      TextShow.GHC.TypeLits
@@ -14,6 +15,9 @@ Portability: GHC
 module TextShow.GHC.TypeLits () where
 
 import GHC.TypeLits (SomeNat(..), SomeSymbol(..), natVal, symbolVal)
+#if MIN_VERSION_base(4,16,0)
+import GHC.TypeLits (SomeChar(..), charVal)
+#endif
 
 import Prelude ()
 import Prelude.Compat
@@ -21,6 +25,15 @@ import Prelude.Compat
 import TextShow.Classes (TextShow(..))
 import TextShow.Data.Char ()
 import TextShow.Data.Integral ()
+
+#if MIN_VERSION_base(4,18,0)
+import Data.Text.Lazy.Builder (fromString)
+import GHC.Show (appPrec, appPrec1)
+import GHC.TypeLits ( SNat, SSymbol, SChar
+                    , fromSNat, fromSSymbol, fromSChar
+                    )
+import TextShow.Classes (showbParen)
+#endif
 
 -- | /Since: 2/
 instance TextShow SomeNat where
@@ -31,3 +44,36 @@ instance TextShow SomeNat where
 instance TextShow SomeSymbol where
     showb (SomeSymbol x) = showbList $ symbolVal x
     {-# INLINE showb #-}
+
+#if MIN_VERSION_base(4,16,0)
+-- | /Since: 3.10.1/
+instance TextShow SomeChar where
+    showbPrec p (SomeChar x) = showbPrec p $ charVal x
+    {-# INLINE showbPrec #-}
+#endif
+
+#if MIN_VERSION_base(4,18,0)
+-- | /Since: 3.10.1/
+instance TextShow (SNat n) where
+  showbPrec p sn
+    = showbParen (p > appPrec)
+      ( fromString "SNat @"
+     <> showbPrec appPrec1 (fromSNat sn)
+      )
+
+-- | /Since: 3.10.1/
+instance TextShow (SSymbol s) where
+  showbPrec p ss
+    = showbParen (p > appPrec)
+      ( fromString "SSymbol @"
+     <> showbList (fromSSymbol ss)
+      )
+
+-- | /Since: 3.10.1/
+instance TextShow (SChar c) where
+  showbPrec p sc
+    = showbParen (p > appPrec)
+      ( fromString "SChar @"
+     <> showbPrec appPrec1 (fromSChar sc)
+      )
+#endif

--- a/tests/Instances/GHC/TypeLits.hs
+++ b/tests/Instances/GHC/TypeLits.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE PolyKinds #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -19,6 +20,12 @@ import Prelude ()
 import Prelude.Compat
 
 import Test.QuickCheck (Arbitrary(..), getNonNegative)
+import Test.QuickCheck.Instances ()
+
+#if MIN_VERSION_base(4,18,0)
+import qualified GHC.TypeNats as TN
+import Spec.Utils (GArbitrary(..), Some(..))
+#endif
 
 instance Arbitrary SomeNat where
     arbitrary = do
@@ -29,3 +36,25 @@ instance Arbitrary SomeNat where
 
 instance Arbitrary SomeSymbol where
     arbitrary = someSymbolVal <$> arbitrary
+
+#if MIN_VERSION_base(4,16,0)
+instance Arbitrary SomeChar where
+    arbitrary = someCharVal <$> arbitrary
+#endif
+
+#if MIN_VERSION_base(4,18,0)
+instance GArbitrary SNat where
+  garbitrary = do
+    n <- arbitrary
+    TN.withSomeSNat n (pure . Some)
+
+instance GArbitrary SSymbol where
+  garbitrary = do
+    s <- arbitrary
+    withSomeSSymbol s (pure . Some)
+
+instance GArbitrary SChar where
+  garbitrary = do
+    c <- arbitrary
+    withSomeSChar c (pure . Some)
+#endif

--- a/tests/Spec/Data/IntegralSpec.hs
+++ b/tests/Spec/Data/IntegralSpec.hs
@@ -24,8 +24,6 @@ import Spec.Utils (matchesTextShowSpec)
 import Test.Hspec (Spec, describe, hspec, parallel)
 
 #if !defined(mingw32_HOST_OS) && MIN_VERSION_text(1,0,0)
-import Control.Applicative (liftA2)
-
 import Data.Char (intToDigit)
 
 import Numeric (showIntAtBase)
@@ -75,7 +73,7 @@ spec = parallel $ do
 #if !defined(mingw32_HOST_OS) && MIN_VERSION_text(1,0,0)
 prop_showIntAtBase :: Gen Expectation
 prop_showIntAtBase = do
-    base <- arbitrary `suchThat` liftA2 (&&) (> 1) (<= 16)
+    base <- arbitrary `suchThat` \b -> 1 < b && b <= 16
     i    <- getNonNegative <$> arbitrary :: Gen Int
     pure $ fromString (showIntAtBase base intToDigit i "") `shouldBe` showbIntAtBase base intToDigit i
 #endif

--- a/tests/Spec/GHC/TypeLitsSpec.hs
+++ b/tests/Spec/GHC/TypeLitsSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 
 {-|
@@ -22,6 +23,9 @@ import Prelude ()
 import Prelude.Compat
 
 import Spec.Utils (matchesTextShowSpec)
+#if MIN_VERSION_base(4,18,0)
+import Spec.Utils (Some)
+#endif
 
 import Test.Hspec (Spec, describe, hspec, parallel)
 
@@ -34,3 +38,15 @@ spec = parallel $ do
         matchesTextShowSpec (Proxy :: Proxy SomeNat)
     describe "SomeSymbol" $
         matchesTextShowSpec (Proxy :: Proxy SomeSymbol)
+#if MIN_VERSION_base(4,16,0)
+    describe "SomeChar" $
+        matchesTextShowSpec (Proxy :: Proxy SomeChar)
+#endif
+#if MIN_VERSION_base(4,18,0)
+    describe "Some SNat" $
+        matchesTextShowSpec (Proxy :: Proxy (Some SNat))
+    describe "Some SSymbol" $
+        matchesTextShowSpec (Proxy :: Proxy (Some SSymbol))
+    describe "Some SChar" $
+        matchesTextShowSpec (Proxy :: Proxy (Some SChar))
+#endif

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -52,7 +52,9 @@ tested-with:         GHC == 7.8.4
                    , GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.2
-                   , GHC == 9.2.2
+                   , GHC == 9.2.7
+                   , GHC == 9.4.4
+                   , GHC == 9.6.1
 extra-source-files:  CHANGELOG.md, README.md, include/*.h
 cabal-version:       >=1.10
 

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -175,14 +175,14 @@ library
                      , th-lift               >= 0.7.6  && < 1
 
   if flag(base-4-9)
-    build-depends:     base                  >= 4.9 && < 4.18
+    build-depends:     base                  >= 4.9 && < 4.19
     cpp-options:       "-DNEW_FUNCTOR_CLASSES"
   else
     build-depends:     base                  >= 4.7 && < 4.9
 
   if flag(template-haskell-2-11)
-    build-depends:     template-haskell      >= 2.11 && < 2.20
-                     , ghc-boot-th           >= 8.0  && < 9.5
+    build-depends:     template-haskell      >= 2.11 && < 2.21
+                     , ghc-boot-th           >= 8.0  && < 9.7
   else
     build-depends:     template-haskell      >= 2.9  && < 2.11
 
@@ -364,14 +364,14 @@ test-suite spec
                      , hspec                 >= 2      && < 3
                      , QuickCheck            >= 2.12   && < 2.15
                      , quickcheck-instances  >= 0.3.28 && < 0.4
-                     , template-haskell      >= 2.9    && < 2.20
+                     , template-haskell      >= 2.9    && < 2.21
                      , text                  >= 0.11.1 && < 2.1
                      , text-show
                      , transformers-compat   >= 0.5    && < 1
   build-tool-depends:  hspec-discover:hspec-discover
 
   if flag(base-4-9)
-    build-depends:     base                  >= 4.9 && < 4.18
+    build-depends:     base                  >= 4.9 && < 4.19
     cpp-options:       "-DNEW_FUNCTOR_CLASSES"
   else
     build-depends:     base                  >= 4.7 && < 4.9
@@ -396,7 +396,7 @@ test-suite spec
 benchmark bench
   type:                exitcode-stdio-1.0
   main-is:             Bench.hs
-  build-depends:       base      >= 4.5    && < 4.18
+  build-depends:       base      >= 4.5    && < 4.19
                      , criterion >= 1.1.4  && < 2
                      , deepseq   >= 1.3    && < 2
                      , ghc-prim


### PR DESCRIPTION
* Adapt to `Solo` data constructor becoming MkSolo in `ghc-prim-0.10.0`
* Add `TextShow` instances for `SomeChar` and `S{Nat,Symbol,Char}`
* Bump upper version bounds for GHC 9.6
* Avoid `liftA2`-related import warning in GHC 9.6

Fixes #59.