### PR TITLE
Fix ghc 9.11 build.

### DIFF
--- a/src/TextShow/GHC/RTS/Flags.hs
+++ b/src/TextShow/GHC/RTS/Flags.hs
@@ -49,7 +49,7 @@ $(deriveTextShow ''ConcFlags)
 -- | /Since: 3.9/
 $(deriveTextShow ''IoSubSystem)
 # endif
-# if MIN_VERSION_base(4,20,0)
+# if MIN_VERSION_GLASGOW_HASKELL(9,11,0,0)
 $(deriveTextShow ''IoManagerFlag)
 # endif
 -- | /Since: 2/

--- a/src/TextShow/GHC/RTS/Flags.hs
+++ b/src/TextShow/GHC/RTS/Flags.hs
@@ -49,6 +49,9 @@ $(deriveTextShow ''ConcFlags)
 -- | /Since: 3.9/
 $(deriveTextShow ''IoSubSystem)
 # endif
+# if MIN_VERSION_base(4,20,0)
+$(deriveTextShow ''IoManagerFlag)
+# endif
 -- | /Since: 2/
 $(deriveTextShow ''MiscFlags)
 -- | /Since: 2/


### PR DESCRIPTION
This fixes the following build error with GHC 9.11.20240512.
```
[49 of 67] Compiling TextShow.GHC.RTS.Flags ( src/TextShow/GHC/RTS/Flags.hs, /Users/ianwookim/repo/mercury/mwb-on-ghcHEAD/20240506/mwb-20240506/dist-newstyle/build/aarch64-osx/ghc-9.11.20240512/text-show-3.10.5/noopt/build/TextShow/GHC/RTS/Flags.dyn_o )
src/TextShow/GHC/RTS/Flags.hs:53:2: error: [GHC-39999]
    • No instance for ‘TextShow.Classes.TextShow IoManagerFlag’
        arising from a use of ‘TextShow.Classes.showbPrec’
    • In the first argument of ‘(<>)’, namely
        ‘TextShow.Classes.showbPrec 0 arg11_a1iZs’
      In the second argument of ‘(<>)’, namely
        ‘(TextShow.Classes.showbPrec 0 arg11_a1iZs
            <>
              (TextShow.Classes.showbCommaSpace
                 <>
                   (Data.Text.Internal.Builder.fromString "numIoWorkerThreads = "
                      <>
                        (TextShow.Classes.showbPrec 0 arg12_a1iZt
                           <> Data.Text.Internal.Builder.singleton '}'))))’
      In the second argument of ‘(<>)’, namely
        ‘(Data.Text.Internal.Builder.fromString "ioManager = "
            <>
              (TextShow.Classes.showbPrec 0 arg11_a1iZs
                 <>
                   (TextShow.Classes.showbCommaSpace
                      <>
                        (Data.Text.Internal.Builder.fromString "numIoWorkerThreads = "
                           <>
                             (TextShow.Classes.showbPrec 0 arg12_a1iZt
                                <> Data.Text.Internal.Builder.singleton '}')))))’
   |
53 | $(deriveTextShow ''MiscFlags)
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Could you add this here or to head.hackage patch list, (as you prefer)? Thanks!