### PR TITLE
Support building with `base-4.21` (GHC 9.12)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240708
+# version: 0.19.20241021
 #
-# REGENDATA ("0.19.20240708",["github","--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.19.20241021",["github","--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.20241014
+            compilerKind: ghc
+            compilerVersion: 9.12.20241014
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -97,6 +102,7 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
@@ -121,7 +127,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -150,6 +156,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -203,6 +221,9 @@ jobs:
           package text-show
             ghc-options: -Werror
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(text-show)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.11 [????.??.??]
+* Support building with GHC 9.12.
+* Add a `TextShow` instance for `IoManagerFlag` in `TextShow.GHC.RTS.Flags`
+  (if building with `base-4.21`/GHC 9.12 or later).
 * Drop support for pre-8.0 versions of GHC.
 * Remove `TextShow.Data.OldTypeable`. The code in this module only worked with
   old versions of GHC that are no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## next [????.??.??]
+## 3.11 [????.??.??]
 * Drop support for pre-8.0 versions of GHC.
 * Remove `TextShow.Data.OldTypeable`. The code in this module only worked with
   old versions of GHC that are no longer supported.

--- a/src/TextShow/GHC/RTS/Flags.hs
+++ b/src/TextShow/GHC/RTS/Flags.hs
@@ -16,6 +16,11 @@ Portability: GHC
 module TextShow.GHC.RTS.Flags () where
 
 import GHC.RTS.Flags
+#if MIN_VERSION_base(4,21,0)
+import qualified GHC.IO.SubSystem as SubSystem
+#elif MIN_VERSION_base(4,15,0)
+import qualified GHC.RTS.Flags as SubSystem
+#endif
 
 import TextShow.Data.Bool     ()
 import TextShow.Data.Char     ()
@@ -42,7 +47,11 @@ $(deriveTextShow ''GCFlags)
 $(deriveTextShow ''ConcFlags)
 #if MIN_VERSION_base(4,15,0)
 -- | /Since: 3.9/
-$(deriveTextShow ''IoSubSystem)
+$(deriveTextShow ''SubSystem.IoSubSystem)
+#endif
+#if MIN_VERSION_base(4,21,0)
+-- | /Since: 3.11/
+$(deriveTextShow ''IoManagerFlag)
 #endif
 -- | /Since: 2/
 $(deriveTextShow ''MiscFlags)

--- a/tests/Instances/GHC/RTS/Flags.hs
+++ b/tests/Instances/GHC/RTS/Flags.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -29,9 +30,17 @@ module Instances.GHC.RTS.Flags
 
 import qualified Generics.Deriving.TH as Generics (deriveAll0)
 import           GHC.RTS.Flags
+#if MIN_VERSION_base(4,21,0)
+import qualified GHC.IO.SubSystem as SubSystem
+#elif MIN_VERSION_base(4,15,0)
+import qualified GHC.RTS.Flags as SubSystem
+#endif
 import           Instances.Utils.GenericArbitrary (genericArbitrary)
 import           Language.Haskell.TH.Lib (conT)
 import           Test.QuickCheck (Arbitrary(..))
+#if MIN_VERSION_base(4,21,0)
+import           Test.QuickCheck (arbitraryBoundedEnum)
+#endif
 import           TextShow.TH.Names
 
 #if !(MIN_VERSION_base(4,15,0))
@@ -55,7 +64,7 @@ $(Generics.deriveAll0 doTraceTypeName)
 #endif
 
 #if MIN_VERSION_base(4,15,0)
-$(Generics.deriveAll0 ''IoSubSystem)
+$(Generics.deriveAll0 ''SubSystem.IoSubSystem)
 #endif
 
 instance Arbitrary RTSFlags where
@@ -68,8 +77,14 @@ instance Arbitrary ConcFlags where
     arbitrary = genericArbitrary
 
 #if MIN_VERSION_base(4,15,0)
-instance Arbitrary IoSubSystem where
+instance Arbitrary SubSystem.IoSubSystem where
     arbitrary = genericArbitrary
+#endif
+
+#if MIN_VERSION_base(4,21,0)
+deriving instance Bounded IoManagerFlag
+instance Arbitrary IoManagerFlag where
+    arbitrary = arbitraryBoundedEnum
 #endif
 
 instance Arbitrary MiscFlags where

--- a/tests/Spec/GHC/RTS/FlagsSpec.hs
+++ b/tests/Spec/GHC/RTS/FlagsSpec.hs
@@ -36,7 +36,10 @@ spec = parallel $ do
         matchesTextShowSpec (Proxy :: Proxy GCFlags)
     describe "ConcFlags" $
         matchesTextShowSpec (Proxy :: Proxy ConcFlags)
-#if MIN_VERSION_base(4,15,0)
+#if MIN_VERSION_base(4,21,0)
+    describe "IoManagerFlag" $
+        matchesTextShowSpec (Proxy :: Proxy IoManagerFlag)
+#elif MIN_VERSION_base(4,15,0)
     describe "IoSubSystem" $
         matchesTextShowSpec (Proxy :: Proxy IoSubSystem)
 #endif

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -1,5 +1,5 @@
 name:                text-show
-version:             3.10.5
+version:             3.11
 synopsis:            Efficient conversion of values into Text
 description:         @text-show@ offers a replacement for the @Show@ typeclass intended
                      for use with @Text@ instead of @String@s. This package was created

--- a/text-show.cabal
+++ b/text-show.cabal
@@ -64,6 +64,7 @@ tested-with:         GHC == 8.0.2
                    , GHC == 9.6.6
                    , GHC == 9.8.2
                    , GHC == 9.10.1
+                   , GHC == 9.12.1
 extra-source-files:  CHANGELOG.md, README.md
 cabal-version:       >=1.10
 
@@ -149,12 +150,12 @@ library
                        TextShow.TH.Names
                        TextShow.Utils
   build-depends:       array                 >= 0.3      && < 0.6
-                     , base                  >= 4.9      && < 4.21
+                     , base                  >= 4.9      && < 4.22
                      , base-compat-batteries >= 0.11     && < 0.15
                      , bifunctors            >= 5.1      && < 6
                      , bytestring            >= 0.10.8.1 && < 0.13
                      , containers            >= 0.1      && < 0.8
-                     , ghc-boot-th           >= 8.0      && < 9.11
+                     , ghc-boot-th           >= 8.0      && < 9.13
                      , ghc-prim
                      , template-haskell      >= 2.11     && < 2.23
                      , text                  >= 1.1      && < 2.2
@@ -301,7 +302,7 @@ test-suite spec
 
                        TextShow.TH.Names
   build-depends:       array                 >= 0.3      && < 0.6
-                     , base                  >= 4.9      && < 4.21
+                     , base                  >= 4.9      && < 4.22
                      , base-compat-batteries >= 0.11     && < 0.15
                      , base-orphans          >= 0.8.5    && < 0.10
                      , bytestring            >= 0.10.8.1 && < 0.13
@@ -329,7 +330,7 @@ test-suite spec
 benchmark bench
   type:                exitcode-stdio-1.0
   main-is:             Bench.hs
-  build-depends:       base      >= 4.9    && < 4.21
+  build-depends:       base      >= 4.9    && < 4.22
                      , criterion >= 1.1.4  && < 2
                      , deepseq   >= 1.3    && < 2
                      , ghc-prim


### PR DESCRIPTION
This adds a `TextShow` for `IoManagerFlag` in `TextShow.GHC.RTS.Flags`. This also adds support for `IoManagerFlag` in the test suite.

This patch is heavily inspired by Ian-Woo Kim's earlier work in https://github.com/RyanGlScott/text-show/pull/63, as well as the corresponding `head.hackage` patch in https://gitlab.haskell.org/ghc/head.hackage/-/merge_requests/369.

Supersedes https://github.com/RyanGlScott/text-show/pull/63.