### PR TITLE
Support building on GHC 9.12 JS backend

### DIFF
--- a/src/TextShow/GHC/Conc/Windows.hs
+++ b/src/TextShow/GHC/Conc/Windows.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP             #-}
 
-#if !defined(__GHCJS__) && defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && defined(mingw32_HOST_OS)
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 #endif
@@ -19,7 +19,7 @@ Only provided if using Windows, and not using GHCJS.
 -}
 module TextShow.GHC.Conc.Windows () where
 
-#if !defined(__GHCJS__) && defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && defined(mingw32_HOST_OS)
 import GHC.Conc.Windows (ConsoleEvent)
 import TextShow.TH.Internal (deriveTextShow)
 

--- a/src/TextShow/GHC/Event.hs
+++ b/src/TextShow/GHC/Event.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP             #-}
 
-#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && !defined(mingw32_HOST_OS)
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -20,7 +20,7 @@ Only provided if using a platform other than Windows or GHCJS.
 -}
 module TextShow.GHC.Event () where
 
-#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && !defined(mingw32_HOST_OS)
 import Data.List (intersperse)
 import Data.Maybe (catMaybes)
 import Data.Text.Lazy.Builder (Builder, singleton)

--- a/tests/Instances/GHC/Conc/Windows.hs
+++ b/tests/Instances/GHC/Conc/Windows.hs
@@ -14,7 +14,7 @@ Portability: GHC
 -}
 module Instances.GHC.Conc.Windows () where
 
-#if !defined(__GHCJS__) && defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && defined(mingw32_HOST_OS)
 import GHC.Conc.Windows (ConsoleEvent(..))
 import Test.QuickCheck (Arbitrary(..), arbitraryBoundedEnum)
 

--- a/tests/Instances/GHC/Event.hs
+++ b/tests/Instances/GHC/Event.hs
@@ -14,7 +14,7 @@ Portability: GHC
 -}
 module Instances.GHC.Event () where
 
-#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && !defined(mingw32_HOST_OS)
 import GHC.Event (Event, Lifetime(..), evtRead, evtWrite)
 
 import Prelude ()

--- a/tests/Spec/GHC/Conc/WindowsSpec.hs
+++ b/tests/Spec/GHC/Conc/WindowsSpec.hs
@@ -19,7 +19,7 @@ import Prelude.Compat
 
 import Test.Hspec (Spec, hspec, parallel)
 
-#if !defined(__GHCJS__) && defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && defined(mingw32_HOST_OS)
 import Data.Proxy (Proxy(..))
 import GHC.Conc.Windows (ConsoleEvent)
 import Spec.Utils (matchesTextShowSpec)
@@ -31,7 +31,7 @@ main = hspec spec
 
 spec :: Spec
 spec = parallel $
-#if !defined(__GHCJS__) && defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && defined(mingw32_HOST_OS)
     describe "ConsoleEvent" $
         matchesTextShowSpec (Proxy :: Proxy ConsoleEvent)
 #else

--- a/tests/Spec/GHC/EventSpec.hs
+++ b/tests/Spec/GHC/EventSpec.hs
@@ -19,7 +19,7 @@ import Prelude.Compat
 
 import Test.Hspec (Spec, hspec, parallel)
 
-#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && !defined(mingw32_HOST_OS)
 import Data.Proxy (Proxy(..))
 
 import GHC.Event (Event, Lifetime)
@@ -35,7 +35,7 @@ main = hspec spec
 
 spec :: Spec
 spec = parallel $ do
-#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS)
+#if !defined(__GHCJS__) && !defined(ghcjs_HOST_OS) && !defined(mingw32_HOST_OS)
     describe "Event" $
         matchesTextShowSpec (Proxy :: Proxy Event)
 --     describe "FdKey" $


### PR DESCRIPTION
Apparently `__GHCJS__` isn't defined on the GHC JS backend.