### PR TITLE
Guard Solo tests on base-4.16

### DIFF
--- a/tests/Spec/Data/TupleSpec.hs
+++ b/tests/Spec/Data/TupleSpec.hs
@@ -13,7 +13,7 @@ Portability: GHC
 module Spec.Data.TupleSpec (main, spec) where
 
 import Data.Proxy (Proxy(..))
-#if MIN_VERSION_ghc_prim(0,7,0)
+#if MIN_VERSION_ghc_prim(0,7,0) && MIN_VERSION_base(4,16,0)
 import GHC.Tuple (Solo)
 #endif
 import Instances.Data.Tuple ()
@@ -84,7 +84,7 @@ spec = parallel $ do
         matchesTextShowSpec (Proxy :: Proxy (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int))
     describe "(Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)" $ do
         matchesTextShowSpec (Proxy :: Proxy (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int))
-#if MIN_VERSION_ghc_prim(0,7,0)
+#if MIN_VERSION_ghc_prim(0,7,0) && MIN_VERSION_base(4,16,0)
     describe "Solo Int" $ do
         let p :: Proxy (Solo Int)
             p = Proxy


### PR DESCRIPTION
The Solo tests require both GHC.Tuple.Solo and a QuickCheck Arbitrary instance for Solo. GHC 9.0 has Solo via ghc-prim-0.7, but its base-4.15 means QuickCheck does not provide Arbitrary (Solo a), causing the GHC 9.0.2 CI job to fail when compiling the test suite.

Require base >= 4.16 for these tests, matching the QuickCheck condition under which the Arbitrary instance is available.

Fixes the CI failure on GHC 9.0.2.